### PR TITLE
Improve command line interface and display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,154 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "elevator-optimization"
 version = "0.1.0"
 dependencies = [
+ "clap",
+ "crossterm",
  "rand",
 ]
 
@@ -27,16 +166,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "mio"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -69,7 +283,175 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5"
+crossterm = "0.27.0"
+clap = { version = "4.4.6", features = [ "derive" ]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,24 @@
+//Import library modules
+use clap::{Parser};
+
+/** ElevatorCli struct schema
+ *
+ * The ElevatorCli struct is used to store the command line
+ * arguments passed into the application/
+ */
+#[derive(Parser)]
+#[command(name="Elevator Optimization")]
+#[command(author="whatsacomputertho")]
+#[command(version="0.1.0")]
+#[command(
+    about="Simulate an elevator, measure wait time and energy usage",
+    long_about="The Elevator Optimization CLI implements elevator simulation logic. \
+                It models people arriving and leaving to and from the building, and \
+                measures the elevator's energy usage, as well as average wait time \
+                throughout the building.  The objective is to minimize with respect \
+                to these measurements under various conditions."
+)]
+pub struct ElevatorCli {
+    #[arg(long="floors")]
+    pub floors: Option<usize>
+}

--- a/src/elevator.rs
+++ b/src/elevator.rs
@@ -183,20 +183,73 @@ impl Extend<Person> for Elevator {
 impl People for Elevator {
     /** get_dest_floors function
      *
-     * Loop through the people on the elevator and calculate each
-     * person's destination floor.  Return a vector of floor indices
+     * Call the people vec implementation of the function and return
+     * the result.
      */
     fn get_dest_floors(&self) -> Vec<usize> {
-        //Return the destination floors of the people on the elevator
         self.people.get_dest_floors()
+    }
+
+    /** get_num_people function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_num_people(&self) -> usize {
+        self.people.get_num_people()
+    }
+
+    /** get_num_people_waiting function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_num_people_waiting(&self) -> usize {
+        self.people.get_num_people_waiting()
+    }
+
+    /** get_aggregate_wait_time function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_aggregate_wait_time(&self) -> usize {
+        self.people.get_aggregate_wait_time()
+    }
+
+    /** are_people_waiting funciton
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn are_people_waiting(&self) -> bool {
+        self.people.are_people_waiting()
     }
 
     /** are_people_going_to_floor funciton
      *
-     * Determine whether there are people going to the given floor
-     * Return a boolean representing this
+     * Call the people vec implementation of the function and return
+     * the result.
      */
     fn are_people_going_to_floor(&self, floor_index: usize) -> bool {
         self.people.are_people_going_to_floor(floor_index)
+    }
+
+    /** increment_wait_times funciton
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn increment_wait_times(&mut self) {
+        self.people.increment_wait_times()
+    }
+
+    /** reset_wait_times funciton
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn reset_wait_times(&mut self) {
+        self.people.reset_wait_times()
     }
 }

--- a/src/floor.rs
+++ b/src/floor.rs
@@ -12,7 +12,7 @@ use crate::people::People;
  * - people (Vec<Person>): A vector of people currently on the floor
  */
  pub struct Floor {
-    pub people: Vec<Person>
+    people: Vec<Person>
 }
 
 /** Floor type implementation
@@ -33,29 +33,6 @@ impl Floor {
         Floor {
             people: Vec::new()
         }
-    }
-
-    /** are_people_waiting function
-     *
-     * Check if there are any people waiting on the floor
-     */
-    pub fn are_people_waiting(&self) -> bool {
-        //Initialize a bool to track if there are people waiting
-        let mut is_person_waiting: bool = false;
-
-        //Loop through the people on the floor and check if any are waiting
-        for pers in self.people.iter() {
-            if pers.floor_on == pers.floor_to {
-                continue;
-            }
-
-            //Break if waiting person is found
-            is_person_waiting = true;
-            break;
-        }
-
-        //Return the boolean tracking if there is someone waiting
-        is_person_waiting
     }
 
     /** get_num_people_waiting function
@@ -149,20 +126,89 @@ impl Extend<Person> for Floor {
 impl People for Floor {
     /** get_dest_floors function
      *
-     * Loop through the people on the floor and calculate each
-     * person's destination floor.  Return a vector of floor indices
+     * Call the people vec implementation of the function and return
+     * the result.
      */
     fn get_dest_floors(&self) -> Vec<usize> {
-        //Return the destination floors of the people on the floor
         self.people.get_dest_floors()
+    }
+
+    /** get_num_people function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_num_people(&self) -> usize {
+        self.people.get_num_people()
+    }
+
+    /** get_num_people_waiting function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_num_people_waiting(&self) -> usize {
+        self.people.get_num_people_waiting()
+    }
+
+    /** get_aggregate_wait_time function
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn get_aggregate_wait_time(&self) -> usize {
+        self.people.get_aggregate_wait_time()
     }
 
     /** are_people_going_to_floor funciton
      *
-     * Determine whether there are people going to the given floor
-     * Return a boolean representing this
+     * Call the people vec implementation of the function and return
+     * the result.
      */
     fn are_people_going_to_floor(&self, floor_index: usize) -> bool {
         self.people.are_people_going_to_floor(floor_index)
+    }
+
+    /** are_people_waiting funciton
+     *
+     * Call the people vec implementation of the function and return
+     * the result.
+     */
+    fn are_people_waiting(&self) -> bool {
+        self.people.are_people_waiting()
+    }
+
+    /** increment_wait_times funciton
+     *
+     * Only increment the wait times of people who are waiting
+     */
+    fn increment_wait_times(&mut self) {
+        //Loop through the people
+        for pers in self.people.iter_mut() {
+            //If the person is not waiting, then skip
+            if pers.floor_on == pers.floor_to {
+                continue;
+            }
+
+            //Increment the person's wait time if they are waiting
+            pers.increment_wait_time();
+        }
+    }
+
+    /** reset_wait_times funciton
+     *
+     * Only reset the wait times of people who are not waiting
+     */
+    fn reset_wait_times(&mut self) {
+        //Loop through the people
+        for pers in self.people.iter_mut() {
+            //If the person is waiting, then skip
+            if pers.floor_on != pers.floor_to {
+                continue;
+            }
+
+            //Reset the person's wait time if they are not waiting
+            pers.reset_wait_time();
+        }
     }
 }

--- a/src/people.rs
+++ b/src/people.rs
@@ -5,11 +5,29 @@ use crate::person::Person;
 pub trait People {
     fn get_dest_floors(&self) -> Vec<usize>;
 
+    fn get_num_people(&self) -> usize;
+
+    fn get_num_people_waiting(&self) -> usize;
+
+    fn get_aggregate_wait_time(&self) -> usize;
+
     fn are_people_going_to_floor(&self, floor_index: usize) -> bool;
+
+    fn are_people_waiting(&self) -> bool;
+
+    fn increment_wait_times(&mut self);
+
+    fn reset_wait_times(&mut self);
 }
 
 //Implement people trait for Vec<Person>
 impl People for Vec<Person> {
+    /** get_dest_floors function
+     *
+     * For a collection of people, return a vector of their destination
+     * floors.  The floor indices should not necessarily be unique
+     * as we may want to understand which is the most popular floor.
+     */
     fn get_dest_floors(&self) -> Vec<usize> {
         //Initialize a new vector of usizes
         let mut dest_floors: Vec<usize> = Vec::new();
@@ -25,6 +43,64 @@ impl People for Vec<Person> {
         dest_floors
     }
 
+    /** get_num_people function
+     *
+     * For a collection of people, return a usize describing how
+     * many of them there are.
+     */
+     fn get_num_people(&self) -> usize {
+        //Return the length of the vector
+        self.len()
+    }
+
+    /** get_num_people_waiting function
+     *
+     * For a collection of people, return a usize describing how
+     * many of them are currently waiting for the elevator.
+     */
+    fn get_num_people_waiting(&self) -> usize {
+        //Initialize a usize counting the numper of people waiting
+        let mut num_waiting: usize = 0_usize;
+
+        //Loop through the vector of persons
+        for pers in self.iter() {
+            //Skip if the person is not waiting
+            if pers.floor_on == pers.floor_to {
+                continue;
+            }
+
+            //If the person is waiting, increment the counter
+            num_waiting += 1_usize;
+        }
+
+        //Return the counter
+        num_waiting
+    }
+
+    /** get_aggregate_wait_time function
+     *
+     * For a collection of people, return a usize counting the
+     * total number of time steps they've been waiting.
+     */
+    fn get_aggregate_wait_time(&self) -> usize {
+        //Initialize a usize for the number of time steps the people spent waiting
+        let mut aggregate_wait_time: usize = 0_usize;
+
+        //Loop through the vector of persons
+        for pers in self.iter() {
+            //Increment the usize with their wait time
+            aggregate_wait_time += pers.wait_time;
+        }
+
+        //Return the usize
+        aggregate_wait_time
+    }
+
+    /** are_people_going_to_floor function
+     *
+     * For a collection of people, return a boolean signifying whether
+     * any of them are going to a given floor.
+     */
     fn are_people_going_to_floor(&self, floor_index: usize) -> bool {
         //Initialize a boolean tracking if people are going to the given floor
         let mut is_going_to_floor: bool = false;
@@ -43,5 +119,52 @@ impl People for Vec<Person> {
 
         //Return the is_going_to_floor boolean
         is_going_to_floor
+    }
+
+    /** are_people_waiting function
+     *
+     * For a collection of people, return a boolean signifying whether
+     * any of them are waiting.
+     */
+    fn are_people_waiting(&self) -> bool {
+        //Initialize a boolean tracking if people are waiting
+        let mut is_waiting: bool = false;
+
+        //Loop through the people and check if they are waiting
+        for pers in self.iter() {
+            //If the person is not waiting, then skip
+            if pers.floor_on == pers.floor_to {
+                continue;
+            }
+
+            //Otherwise update the boolean and break
+            is_waiting = true;
+            break;
+        }
+
+        //Return the is_going_to_floor boolean
+        is_waiting
+    }
+
+    /** increment_wait_times function
+     *
+     * For a collection of people, increment their wait times.
+     */
+    fn increment_wait_times(&mut self) {
+        //Loop through the people and increment their wait times
+        for pers in self.iter_mut() {
+            pers.increment_wait_time();
+        }
+    }
+
+    /** reset_wait_times function
+     *
+     * For a collection of people, reset their wait times.
+     */
+    fn reset_wait_times(&mut self) {
+        //Loop through the people and reset their wait times
+        for pers in self.iter_mut() {
+            pers.reset_wait_time();
+        }
     }
 }

--- a/src/person.rs
+++ b/src/person.rs
@@ -14,6 +14,7 @@ pub struct Person {
     pub floor_on: usize,
     pub floor_to: usize,
     pub is_leaving: bool,
+    pub wait_time: usize,
     dst_out: Bernoulli
 }
 
@@ -46,6 +47,7 @@ impl Person {
             floor_on: 0_usize,
             floor_to: floor_to,
             is_leaving: false,
+            wait_time: 0_usize,
             dst_out: Bernoulli::new(p_out).unwrap()
         }
     }
@@ -69,6 +71,25 @@ impl Person {
             self.is_leaving = pers_is_leaving;
         }
         self.is_leaving
+    }
+
+    /** increment_wait_time function
+     *
+     * Increment the person's wait time counter
+     */
+    pub fn increment_wait_time(&mut self) {
+        //Increment the person's wait time counter
+        self.wait_time += 1_usize;
+    }
+
+    /** reset_wait_time function
+     *
+     * Reset the person's wait time counter, presumably
+     * once they reach their destination floor.
+     */
+    pub fn reset_wait_time(&mut self) {
+        //Reset the person's wait time counter
+        self.wait_time = 0_usize;
     }
 }
 


### PR DESCRIPTION
In this PR, I add the following features
- Static command line display: Display is refreshed on each time step and overwritten
- CLI: Input the number of floors via the CLI arg `--floors`, more to come soon
- Colored floors: Colored floors indicating that people are waiting on that floor
- Track average energy and wait time